### PR TITLE
MacOS Nix daemon failsafe++

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -19,7 +19,7 @@ cleanup_nix_store() {
 # Check if python3 command is available and Python version is 3.6 or greater
 if command -v python3 &> /dev/null &&
    python_version=$(python3 -c "import sys; print(sys.version_info.major * 10 + sys.version_info.minor)") &&
-   [[ $python_version -ge 39 ]]; then
+   [[ $python_version -ge 40 ]]; then
   run_python_script
   cleanup_nix_store
   else

--- a/install.sh
+++ b/install.sh
@@ -19,7 +19,7 @@ cleanup_nix_store() {
 # Check if python3 command is available and Python version is 3.6 or greater
 if command -v python3 &> /dev/null &&
    python_version=$(python3 -c "import sys; print(sys.version_info.major * 10 + sys.version_info.minor)") &&
-   [[ $python_version -ge 36 ]]; then
+   [[ $python_version -ge 39 ]]; then
   run_python_script
   cleanup_nix_store
   else

--- a/src/dotfiles.py
+++ b/src/dotfiles.py
@@ -1,14 +1,44 @@
 import os
 import platform
+import shutil
+import tempfile
 from typing import NoReturn
-
 from .paths import Network, NetworkPaths, Paths
-from .utils import ind, print_neutral, print_success
+from .utils import ind, print_fail, print_neutral, print_success
+
+# Nix daemon failsafe for MacOS users
+daemon_path = "'/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh'"
+daemon_snippet_lines: list[str] = f"""
+# Nix
+[ -e {daemon_path} ] && . {daemon_path}
+# End Nix\n
+""".splitlines()
+
+
+def overwrite_dotfile_safely(dotfile_path: str, new_content: list[str]):
+    temp_dir = tempfile.mkdtemp()
+    filename = os.path.basename(dotfile_path)
+    backup_path = os.path.join(temp_dir, f"{filename}.bak")
+
+    try:
+        shutil.copy2(dotfile_path, backup_path)
+        with open(dotfile_path, 'w') as dotfile:
+            dotfile.writelines(new_content)
+
+    except Exception as e:
+        print_fail(
+            f'\n{ind(f"An error occurred updating \'{dotfile_path}\': restoring original file.")}\n')
+        shutil.copy2(backup_path, dotfile_path)
+        raise e
+
+    finally:
+        shutil.rmtree(temp_dir)
 
 
 def update_dotfiles(paths: Paths) -> None | NoReturn:
+    is_darwin = platform.system() == 'Darwin'
     dotfiles = ['.bash_profile', '.bashrc', '.zprofile',
-                '.zshrc'] if platform.system() == 'Darwin' else ['.bashrc']
+                '.zshrc'] if is_darwin else ['.bashrc']
 
     def make_alias(net: Network) -> tuple[str, str]:
         node_alias = f"{'main' if net.value == 'mainnet' else net.value}-node"
@@ -26,8 +56,10 @@ def update_dotfiles(paths: Paths) -> None | NoReturn:
     alias_chunks = [make_alias(net) for net in Network]
     aliases = [f"{alias}{value}" for alias, value in alias_chunks]
 
-    def not_alias(line):
-        return not any(line.startswith(prefix) for prefix, _ in alias_chunks)
+    def is_alias_or_socket_path(line):
+        is_alias = any(line.startswith(prefix) for prefix, _ in alias_chunks)
+        is_socket_path = line.startswith("export CARDANO_NODE_SOCKET_PATH")
+        return is_alias or is_socket_path
 
     for dotfile in dotfiles:
         file_path = os.path.expanduser(f"~/{dotfile}")
@@ -35,20 +67,27 @@ def update_dotfiles(paths: Paths) -> None | NoReturn:
             print_neutral(ind(f"> Creating '{file_path}' file..."))
             open(file_path, 'a').close()
 
-        print_neutral(
-            ind(f"> Adding socket variable and aliases to '{file_path}'"))
+        print_neutral(ind(
+            f"> Adding {'Nix daemon failsafe,' if is_darwin else ''} socket variable and aliases to '{file_path}'"))
 
         with open(file_path, 'r') as f:
             lines = f.readlines()
-
             new_socket = f"export CARDANO_NODE_SOCKET_PATH='{paths.socket}'\n"
-            dotfile_contents = [
-                line for line in lines
-                if not_alias(line) and
-                not line.startswith("export CARDANO_NODE_SOCKET_PATH")] + [
-                new_socket, *aliases]
+            common_content = [new_socket, *aliases]
 
-        with open(file_path, 'w') as f:
-            f.writelines(dotfile_contents)
+            linux_content = [
+                line for line in lines
+                if not is_alias_or_socket_path(line)
+            ] + common_content
+            # Add Nix daemon failsafe to user dotfiles on darwin
+            # (Prevents breakage of Nix from MacOS system updates)
+            darwin_content = daemon_snippet_lines + [
+                line for line in lines
+                if
+                not is_alias_or_socket_path(line) and
+                not line.strip() in daemon_snippet_lines] + common_content
+
+        overwrite_dotfile_safely(
+            file_path, darwin_content if is_darwin else linux_content)
 
         print_success(ind(f"> {dotfile}: SUCCESS\n"))

--- a/src/dotfiles.py
+++ b/src/dotfiles.py
@@ -11,7 +11,7 @@ daemon_path = "'/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh'"
 daemon_snippet_lines = [
     "# Nix\n",
     f"[ -e {daemon_path} ] && . {daemon_path}" + "\n",
-    "# End Nix\n\n"]
+    "# End Nix\n"]
 
 
 def overwrite_dotfile_safely(dotfile_path: str, new_content: list[str]):
@@ -80,7 +80,7 @@ def update_dotfiles(paths: Paths) -> None | NoReturn:
             ] + common_content
             # Add Nix daemon failsafe to user dotfiles on darwin
             # (Prevents breakage of Nix from MacOS system updates)
-            darwin_content = daemon_snippet_lines + [
+            darwin_content = [*daemon_snippet_lines, "\n"] + [
                 line for line in lines
                 if
                 not is_alias_or_socket_path(line) and

--- a/src/dotfiles.py
+++ b/src/dotfiles.py
@@ -1,8 +1,8 @@
-from itertools import groupby
 import os
 import platform
 import shutil
 import tempfile
+from itertools import groupby
 from typing import Generator, NoReturn
 from .paths import Network, NetworkPaths, Paths
 from .utils import ind, print_fail, print_neutral, print_success

--- a/src/dotfiles.py
+++ b/src/dotfiles.py
@@ -16,6 +16,9 @@ daemon_snippet_lines = [
 
 
 def remove_excess_newlines(lines: list[str]) -> Generator[str, None, None]:
+    """
+    Prevents accumulation of newlines in dotfiles by removing consecutive newlines in excess of 2.
+    """
     for _, group in groupby(lines, key=lambda line: line.strip() == ""):
         lines_in_group = list(group)
         if not lines_in_group[0].strip():
@@ -26,6 +29,11 @@ def remove_excess_newlines(lines: list[str]) -> Generator[str, None, None]:
 
 def overwrite_dotfile_safely(
         dotfile_path: str, new_content: list[str]) -> None | NoReturn:
+    """
+    Creates a temporary backup of a given dotfile before overwriting its contents.
+    Restores the backup if an exception occurs.
+    """
+
     temp_dir = tempfile.mkdtemp()
     filename = os.path.basename(dotfile_path)
     backup_path = os.path.join(temp_dir, f"{filename}.bak")
@@ -46,6 +54,11 @@ def overwrite_dotfile_safely(
 
 
 def update_dotfiles(paths: Paths) -> None | NoReturn:
+    """
+    Updates the contents of all target dotfiles to include cardano-node socket path and aliases.
+    Removes previous socket path and aliases if present.
+    For Mac users, adds Nix daemon failsafe code to dotfiles to prevent Nix breakage from MacOS updates.
+    """
     is_darwin = platform.system() == 'Darwin'
     dotfiles = ['.bash_profile', '.bashrc', '.zprofile',
                 '.zshrc'] if is_darwin else ['.bashrc']

--- a/src/dotfiles.py
+++ b/src/dotfiles.py
@@ -27,7 +27,7 @@ def overwrite_dotfile_safely(dotfile_path: str, new_content: list[str]):
 
     except Exception as e:
         print_fail(
-            f'\n{ind(f"An error occurred updating \'{dotfile_path}\': restoring original file.")}\n')
+            f'\n{ind(f"An error occurred updating {dotfile_path}: restoring original file.")}\n')
         shutil.copy2(backup_path, dotfile_path)
         raise e
 

--- a/src/dotfiles.py
+++ b/src/dotfiles.py
@@ -8,11 +8,10 @@ from .utils import ind, print_fail, print_neutral, print_success
 
 # Nix daemon failsafe for MacOS users
 daemon_path = "'/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh'"
-daemon_snippet_lines: list[str] = f"""
-# Nix
-[ -e {daemon_path} ] && . {daemon_path}
-# End Nix\n
-""".splitlines()
+daemon_snippet_lines = [
+    "# Nix",
+    f"[ -e {daemon_path} ] && . {daemon_path}",
+    "# End Nix\n"]
 
 
 def overwrite_dotfile_safely(dotfile_path: str, new_content: list[str]):

--- a/src/dotfiles.py
+++ b/src/dotfiles.py
@@ -9,9 +9,9 @@ from .utils import ind, print_fail, print_neutral, print_success
 # Nix daemon failsafe for MacOS users
 daemon_path = "'/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh'"
 daemon_snippet_lines = [
-    "# Nix",
-    f"[ -e {daemon_path} ] && . {daemon_path}",
-    "# End Nix\n"]
+    "# Nix\n",
+    f"[ -e {daemon_path} ] && . {daemon_path}" + "\n",
+    "# End Nix\n\n"]
 
 
 def overwrite_dotfile_safely(dotfile_path: str, new_content: list[str]):

--- a/src/dotfiles.py
+++ b/src/dotfiles.py
@@ -84,7 +84,7 @@ def update_dotfiles(paths: Paths) -> None | NoReturn:
                 line for line in lines
                 if
                 not is_alias_or_socket_path(line) and
-                not line.strip() in daemon_snippet_lines] + common_content
+                not line.strip() + "\n" in daemon_snippet_lines] + common_content
 
         overwrite_dotfile_safely(
             file_path, darwin_content if is_darwin else linux_content)


### PR DESCRIPTION
- Adds a Nix daemon failsafe snippet to Mac user dotfiles to prevent breakage of Nix following MacOS system updates.
- Strips consecutive newlines from dotfiles in excess of 2, to prevent accumulation of newlines from multiple runs.
- Bumps minimum Python version to 3.10 to fix type-related errors from insufficiently high constraint.